### PR TITLE
Adds RoseStacker Hook addon

### DIFF
--- a/thirdparty.json
+++ b/thirdparty.json
@@ -12,6 +12,18 @@
         "verified"
       ]
     },
+	"RoseStacker Hook": {
+      "Author": "BONNe",
+      "AuthorLink": "https://github.com/BONNePlayground",
+      "Releases": "https://github.com/BONNePlayground/RoseStackerHook/releases",
+      "Github": "https://github.com/BONNePlayground/RoseStackerHook",
+      "Issues": "https://github.com/BONNePlayground/RoseStackerHook/issues",
+      "Description": "This addon adds 5 new flags for islands. There is protection flag for accessing stacked item GUI as well as 4 flags that allows toggling stacking for items, blocks, entities and spawners.",
+      "Tags": [
+        "addon",
+        "verified"
+      ]
+    },
     "DragonFight": {
       "Author": "BONNe",
       "AuthorLink": "https://www.spigotmc.org/resources/authors/bonne_lv.640448/",


### PR DESCRIPTION
This addon adds a protection flag to the RoseStacker GUI as well as adds 4 flags for toggling item, block, entity, and spawner stacking.