### PR TITLE
Admin sync: presets, addons

### DIFF
--- a/config.json
+++ b/config.json
@@ -2,36 +2,40 @@
   "addons": [
     {
       "name": "AcidIsland",
-      "gamemode": true,
       "github": "BentoBoxWorld/AcidIsland",
       "ci": "BentoBoxWorld/AcidIsland",
       "description": "**AcidIsland** is a **survival game** where players try to survive and expand their island, surrounded by a **sea of acid**.\n\nAcid is everywhere. Acid burns everything.\n\nOh, and rain is acid too.\n\nCreated and maintained by tastybento.",
+      "gamemode": true,
       "versions": {
-        "1.21.10": "1.20.1",
-        "1.21.6": "1.20.1",
-        "1.21.5": "1.20.1",
-        "1.21.4": "1.20.1",
-        "1.21.3": "1.20.1",
+        "1.21.11": "1.22.0",
+        "1.21.10": "1.21.0",
+        "1.21.6": "1.21.0",
+        "1.21.5": "1.21.0",
+        "1.21.4": "1.21.0",
+        "1.21.3": "1.21.0",
         "1.20.6": "1.19.0",
         "1.19": "1.17.2",
         "1.18": "1.15.2",
         "1.17": "1.15.2",
         "1.16": "1.14.6",
         "1.16-Java16": "1.14.6",
-        "1.15": "1.13.1"
+        "1.15": "1.13.1",
+        "26.1.1": "1.22.0"
       }
     },
     {
       "name": "AOneBlock",
-      "gamemode": true,
       "github": "BentoBoxWorld/AOneBlock",
       "ci": "BentoBoxWorld/AOneBlock",
       "description": "**AOneBlock** is a OneBlock **survival game**\n\nYou spawn on a block. Just *one* block. What do you do?\n\nCreated and maintained by tastybento.",
+      "gamemode": true,
       "versions": {
-        "1.21.10": "1.22.0",
-        "1.21.7": "1.22.0",
-        "1.21.6": "1.21.1",
-        "1.21.5": "1.19.0",
+        "26.1.1": "1.24.0",
+        "1.21.11": "1.24.0",
+        "1.21.10": "1.24.0",
+        "1.21.7": "1.24.0",
+        "1.21.6": "1.24.0",
+        "1.21.5": "1.24.0",
         "1.21.4": "1.19.0",
         "1.21.3": "1.21.1",
         "1.20.6": "1.17.0",
@@ -44,11 +48,12 @@
     },
     {
       "name": "Boxed",
-      "gamemode": true,
       "github": "BentoBoxWorld/Boxed",
       "ci": "BentoBoxWorld/Boxed",
       "description": "**Boxed** is a semi-vanilla **survival game**\n\nA game mode where you are boxed into a tiny space that only expands by completing advancements.\n\n\n\nCreated and maintained by tastybento.",
+      "gamemode": true,
       "versions": {
+        "1.21.11": "3.3.0",
         "1.21.10": "3.3.0",
         "1.21.6": "3.3.0",
         "1.21.5": "3.3.0",
@@ -58,16 +63,18 @@
         "1.19": "2.0.3",
         "1.17": "1.2.1",
         "1.16": "1.1.5",
-        "1.16-Java16": "1.1.5"
+        "1.16-Java16": "1.1.5",
+        "26.1.1": "3.3.0"
       }
     },
     {
       "name": "BSkyBlock",
-      "gamemode": true,
       "github": "BentoBoxWorld/BSkyBlock",
       "ci": "BentoBoxWorld/BSkyBlock",
       "description": "**BSkyBlock** is a **survival game** where players try to survive on an **island in the sky**.\n\nCreated and maintained by tastybento.",
+      "gamemode": true,
       "versions": {
+        "1.21.11": "1.19.1",
         "1.21.10": "1.19.1",
         "1.21.6": "1.19.1",
         "1.21.5": "1.19.1",
@@ -79,15 +86,16 @@
         "1.17": "1.15.2",
         "1.16": "1.14.4",
         "1.16-Java16": "1.15.2",
-        "1.15": "1.14.3"
+        "1.15": "1.14.3",
+        "26.1.1": "1.19.1"
       }
     },
     {
       "name": "CaveBlock",
-      "gamemode": true,
       "github": "BentoBoxWorld/CaveBlock",
       "ci": "BentoBoxWorld/CaveBlock",
       "description": "**CaveBlock** is a **survival game** where players try to survive **underground**.\n\n*An ode to the dwarf's heart in the depths of each person.*\n\nBased on an original idea by the **StoneBlock modpack**.\n\nCreated and maintained by BONNe.",
+      "gamemode": true,
       "versions": {
         "1.21.8": "1.20.1",
         "1.21.6": "1.20.1",
@@ -100,49 +108,56 @@
         "1.17": "1.14.5",
         "1.16": "1.14.5",
         "1.16-Java16": "1.14.5",
-        "1.15": "1.14.0"
+        "1.15": "1.14.0",
+        "26.1.1": "1.20.1",
+        "1.21.10": "1.20.1",
+        "1.21.11": "1.20.1"
       }
     },
     {
       "name": "SkyGrid",
-      "gamemode": true,
       "github": "BentoBoxWorld/SkyGrid",
       "ci": "BentoBoxWorld/SkyGrid",
       "description": "**SkyGrid** is a **survival game** where players try to survive in a world **made up of scattered blocks**.\n\nCreated and maintained by tastybento.",
+      "gamemode": true,
       "versions": {
-        "1.21.10": "2.2.2",
-        "1.21.6": "2.2.2",
-        "1.21.5": "2.2.2",
-        "1.21.4": "2.2.2",
-        "1.21.3": "2.2.2",
-        "1.21.1": "2.2.2",
+        "1.21.10": "2.2.3",
+        "1.21.6": "2.2.3",
+        "1.21.5": "2.2.3",
+        "1.21.4": "2.2.3",
+        "1.21.3": "2.2.3",
+        "1.21.1": "2.2.3",
         "1.20.6": "1.19.0",
         "1.19": "1.19.0",
         "1.17": "1.17.0",
         "1.16": "1.16.0",
         "1.16-Java16": "1.16.0",
-        "1.15": "1.14.1"
+        "1.15": "1.14.1",
+        "1.21.11": "2.2.3",
+        "26.1.1": "2.2.3"
       }
     },
     {
       "name": "Poseidon",
-      "gamemode": true,
       "github": "BentoBoxWorld/poseidon",
       "ci": "BentoBoxWorld/Poseidon",
       "description": "**Poseidon** Welcome to Poseidon, an underwater adventure where the ocean is both your playground and your challenge!\n\nCreated and maintained by tastybento.",
+      "gamemode": true,
       "versions": {
         "1.21.10": "1.1.0",
         "1.21.6": "1.1.0",
         "1.21.5": "1.1.0",
-        "1.21.4": "1.0.0"
+        "1.21.4": "1.0.0",
+        "1.21.11": "1.1.0",
+        "26.1.1": "1.1.0"
       }
     },
     {
       "name": "Parkour",
-      "gamemode": true,
       "github": "BentoBoxWorld/Parkour",
       "ci": "BentoBoxWorld/Parkour",
       "description": "**Parkour** is a game where players create parkour courses and play them.\n\nCreated and maintained by tastybento.",
+      "gamemode": true,
       "versions": {
         "1.21.10": "1.4.0",
         "1.21.6": "1.4.0",
@@ -150,36 +165,40 @@
         "1.21.4": "1.4.0",
         "1.21.3": "1.4.0",
         "1.20.6": "1.3.0",
-        "1.20.1": "1.1.0"
+        "1.20.1": "1.1.0",
+        "1.21.11": "1.4.0",
+        "26.1.1": "1.4.0"
       }
     },
     {
       "name": "Bank",
-      "gamemode": false,
       "github": "BentoBoxWorld/Bank",
       "ci": "BentoBoxWorld/Bank",
       "description": "**Bank** gives island teams a shared bank and provides a ranking system based on island balances.\n\nCreated and maintained by [tastybento](https://github.com/tastybento).",
+      "gamemode": false,
       "versions": {
-        "1.21.6": "1.9.0",
-        "1.21.5": "1.9.0",
-        "1.21.4": "1.9.0",
-        "1.21.3": "1.9.0",
+        "1.21.6": "1.9.1",
+        "1.21.5": "1.9.1",
+        "1.21.4": "1.9.1",
+        "1.21.3": "1.9.1",
         "1.21.1": "1.8.0",
         "1.20.6": "1.7.1",
         "1.19": "1.5.0",
         "1.18": "1.4.0",
         "1.17": "1.4.0",
         "1.16": "1.3.0",
-        "1.16-Java16": "1.4.0"
-
+        "1.16-Java16": "1.4.0",
+        "1.21.11": "1.9.1",
+        "1.21.10": "1.9.1",
+        "26.1.1": "1.9.1"
       }
     },
     {
       "name": "Biomes",
-      "gamemode": false,
       "github": "BentoBoxWorld/Biomes",
       "ci": "BentoBoxWorld/Biomes",
       "description": "**Biomes** lets your players **change the biome** on their island.\n\nCreated and maintained by [BONNe](https://github.com/bonne).",
+      "gamemode": false,
       "versions": {
         "1.21.6": "2.2.1",
         "1.21.5": "2.2.1",
@@ -191,35 +210,41 @@
         "1.17": "1.14.0",
         "1.16": "1.14.0",
         "1.16-Java16": "1.14.0",
-        "1.15": "1.13.0"
+        "1.15": "1.13.0",
+        "1.21.10": "2.2.1",
+        "1.21.11": "2.2.1",
+        "26.1.1": "2.2.1"
       }
     },
     {
       "name": "Border",
-      "gamemode": false,
       "github": "BentoBoxWorld/Border",
       "ci": "BentoBoxWorld/Border",
       "description": "**Border** displays a **world border** around your players' islands.\n\nWorks best with [WorldBorderAPI](https://github.com/yannicklamprecht/WorldBorderAPI/releases).\n\nCreated and maintained by [tastybento](https://github.com/tastybento).",
+      "gamemode": false,
       "versions": {
-        "1.21.6": "4.5.1",
-        "1.21.5": "4.5.1",
-        "1.21.4": "4.5.1",
-        "1.21.3": "4.5.1",
+        "1.21.6": "4.8.3",
+        "1.21.5": "4.8.3",
+        "1.21.4": "4.8.3",
+        "1.21.3": "4.8.3",
         "1.20.6": "4.3.0",
         "1.19": "4.1.1",
         "1.18": "3.2.0",
         "1.17": "3.2.0",
         "1.16": "3.1.1",
         "1.16-Java16": "3.1.1",
-        "1.15": "1.0.7"
+        "1.15": "1.0.7",
+        "1.21.10": "4.8.3",
+        "1.21.11": "4.8.3",
+        "26.1.1": "4.8.3"
       }
     },
     {
       "name": "CauldronWitchery",
-      "gamemode": false,
       "github": "BentoBoxWorld/CauldronWitchery",
       "ci": "BentoBoxWorld/CauldronWitchery",
       "description": "**CauldronWitchery** gives your players the opportunity to get their hands on **black magic**.\nLet them **spawn monsters** using a cauldron!\n\n*What does the Witch do with her cauldron?*\n*Black Magic, of course!*\n\n*We are just not sure what could happen afterward...*\n\nBased on an original idea by the **Ex Nihilo mod**.\n\nCreated and maintained by [BONNe](https://github.com/BONNe).",
+      "gamemode": false,
       "versions": {
         "1.21.6": "2.1.0",
         "1.21.5": "2.1.0",
@@ -231,18 +256,21 @@
         "1.17": "1.6.0",
         "1.16": "1.5.0",
         "1.16-Java16": "1.5.0",
-        "1.15": "1.5.0"
+        "1.15": "1.5.0",
+        "1.21.10": "2.1.0",
+        "1.21.11": "2.1.0",
+        "26.1.1": "2.1.0"
       }
     },
     {
       "name": "Challenges",
-      "gamemode": false,
       "github": "BentoBoxWorld/Challenges",
       "ci": "BentoBoxWorld/Challenges",
       "description": "**Challenges** lets you create Challenges for your **players to complete!**\n\nCreated and maintained by [BONNe](https://github.com/BONNe).",
+      "gamemode": false,
       "versions": {
-        "1.21.6": "1.5.1",
-        "1.21.5": "1.5.1",
+        "1.21.6": "1.6.0",
+        "1.21.5": "1.6.0",
         "1.21.4": "1.5.1",
         "1.21.3": "1.5.1",
         "1.20.6": "1.3.1",
@@ -251,35 +279,41 @@
         "1.17": "1.0.0",
         "1.16": "0.8.4",
         "1.16-Java16": "0.8.4",
-        "1.15": "0.8.4"
+        "1.15": "0.8.4",
+        "1.21.10": "1.6.0",
+        "1.21.11": "1.6.0",
+        "26.1.1": "1.6.0"
       }
     },
     {
       "name": "Chat",
-      "gamemode": false,
       "github": "BentoBoxWorld/Chat",
       "ci": "BentoBoxWorld/Chat",
       "description": "**Chat** lets your players **chat with each other** in an **Island Chat** or a **Team Chat**.\n\nCreated and maintained by [tastybento](https://github.com/tastybento). ",
+      "gamemode": false,
       "versions": {
-        "1.21.6": "1.3.0",
-        "1.21.5": "1.3.0",
-        "1.21.4": "1.3.0",
-        "1.21.3": "1.3.0",
+        "1.21.6": "1.4.1",
+        "1.21.5": "1.4.1",
+        "1.21.4": "1.4.1",
+        "1.21.3": "1.4.1",
         "1.20.6": "1.2.0",
         "1.19": "1.1.4",
         "1.18": "1.1.4",
         "1.17": "1.1.4",
         "1.16": "1.1.4",
         "1.16-Java16": "1.1.4",
-        "1.15": "1.1.1"
+        "1.15": "1.1.1",
+        "1.21.10": "1.4.1",
+        "1.21.11": "1.4.1",
+        "26.1.1": "1.4.1"
       }
     },
     {
       "name": "CheckMeOut",
-      "gamemode": false,
       "github": "BentoBoxWorld/CheckMeOut",
       "ci": "BentoBoxWorld/CheckMeOut",
       "description": "**CheckMeOut**\nis an island submission addon. This addon enables players to submit their island for consideration by admins. In this way, Admins can set up site-wide challenges or competitions that players can do and then submit their island for consideration. Admins get a GUI that lists submissions and they can teleport to the islands from there. Once an island is reviewed by admins it can be deleted, or when the whole activity is over, all submissions can be cleared.\n\nCreated and maintained by [tastybento](https://github.com/tastybento). ",
+      "gamemode": false,
       "versions": {
         "1.21.6": "1.2.0",
         "1.21.5": "1.2.0",
@@ -291,55 +325,64 @@
         "1.17": "1.1.0",
         "1.16": "1.0.2",
         "1.16-Java16": "1.1.0",
-        "1.15": "1.0.2"
+        "1.15": "1.0.2",
+        "1.21.10": "1.2.0",
+        "1.21.11": "1.2.0",
+        "26.1.1": "1.2.0"
       }
     },
     {
       "name": "ControlPanel",
-      "gamemode": false,
       "github": "BentoBoxWorld/ControlPanel",
       "ci": "BentoBoxWorld/ControlPanel",
       "description": "**ControlPanel** lets you design a flexible **Control Panel** your players can use to **manage their island**.\n\nCreated and maintained by [BONNe](https://github.com/BONNe).",
+      "gamemode": false,
       "versions": {
-        "1.21.6": "1.14.0",
-        "1.21.5": "1.14.0",
-        "1.21.4": "1.14.0",
-        "1.21.3": "1.14.0",
+        "1.21.6": "1.16.0",
+        "1.21.5": "1.16.0",
+        "1.21.4": "1.16.0",
+        "1.21.3": "1.16.0",
         "1.20.6": "1.13.1",
         "1.19": "1.13.0",
         "1.18": "1.13.0",
         "1.17": "1.13.0",
         "1.16": "1.13.0",
         "1.16-Java16": "1.13.0",
-        "1.15": "1.13.0"
+        "1.15": "1.13.0",
+        "1.21.10": "1.16.0",
+        "1.21.11": "1.16.0",
+        "26.1.1": "1.16.0"
       }
     },
     {
       "name": "DimensionalTrees",
-      "gamemode": false,
       "github": "BentoBoxWorld/DimensionalTrees",
       "ci": "BentoBoxWorld/DimensionalTrees",
       "description": "**DimensionalTrees** lets you define **exotic tree types** in **other dimensions**.\n\n*Have you ever dreamed of a glowstone tree in the Nether?*\n*What about an end stone and purpur tree in the End?*\n\nCreated by [Awakened-Redstone](https://github.com/Awakened-Redstone) and maintained by the [BentoBoxWorld Crew](https://github.com/orgs/BentoBoxWorld/teams/crew).",
+      "gamemode": false,
       "versions": {
-        "1.21.6": "1.8.0",
-        "1.21.5": "1.8.0",
-        "1.21.4": "1.8.0",
-        "1.21.3": "1.8.0",
+        "1.21.6": "1.9.0",
+        "1.21.5": "1.9.0",
+        "1.21.4": "1.9.0",
+        "1.21.3": "1.9.0",
         "1.20.6": "1.7.0",
         "1.19": "1.6.0",
         "1.18": "1.6.0",
         "1.17": "1.6.0",
         "1.16": "1.6.0",
         "1.16-Java16": "1.6.0",
-        "1.15": "1.6.0"
+        "1.15": "1.6.0",
+        "1.21.10": "1.9.0",
+        "1.21.11": "1.9.0",
+        "26.1.1": "1.9.0"
       }
     },
     {
       "name": "ExtraMobs",
-      "gamemode": false,
       "github": "BentoBoxWorld/ExtraMobs",
       "ci": "BentoBoxWorld/ExtraMobs",
       "description": "**ExtraMobs** changes some mob-spawning rules to make **Shulkers**, **Wither Skeletons** and more **spawn naturally in your worlds**.\n\nCreated and maintained by [BONNe](https://github.com/BONNe).",
+      "gamemode": false,
       "versions": {
         "1.21.6": "1.14.0",
         "1.21.5": "1.14.0",
@@ -351,96 +394,110 @@
         "1.17": "1.11.0.3",
         "1.16": "1.11.0.3",
         "1.16-Java16": "1.11.0.3",
-        "1.15": "1.11.0.2"
+        "1.15": "1.11.0.2",
+        "1.21.10": "1.14.0",
+        "1.21.11": "1.14.0",
+        "26.1.1": "1.14.0"
       }
     },
     {
       "name": "FarmersDance",
-      "gamemode": false,
       "github": "BentoBoxWorld/FarmersDance",
       "ci": "BentoBoxWorld/FarmersDance",
       "description": "**FarmersDance** allows 'dance' around any growable plant to make it growing faster.\n\nCreated and maintained by [BONNe](https://github.com/BONNe).",
+      "gamemode": false,
       "versions": {
         "1.21.6": "1.2.2",
         "1.21.5": "1.2.2",
         "1.21.4": "1.2.2",
-        "1.21.4": "1.2.2",
         "1.21.1": "1.2.0",
         "1.20.6": "1.0.0",
-        "1.19": "1.0.0"
+        "1.19": "1.0.0",
+        "1.21.10": "1.2.2",
+        "1.21.11": "1.2.2",
+        "26.1.1": "1.2.2"
       }
     },
     {
       "name": "Greenhouses",
-      "gamemode": false,
       "github": "BentoBoxWorld/Greenhouses",
       "ci": "BentoBoxWorld/Greenhouses",
       "description": "**Greenhouses** lets your players **create biome greenhouses** on their islands.\n\nInteresting variation to the Biomes addon.\n\nAdapted from tastybento's Greenhouses plugin.\n\nCreated and maintained by [tastybento](https://github.com/tastybento).",
+      "gamemode": false,
       "versions": {
-        "1.21.6": "1.9.2",
-        "1.21.5": "1.9.2",
-        "1.21.4": "1.9.2",
-        "1.21.3": "1.9.2",
+        "1.21.6": "1.9.4",
+        "1.21.5": "1.9.4",
+        "1.21.4": "1.9.4",
+        "1.21.3": "1.9.4",
         "1.20.6": "1.8.0",
         "1.19": "1.7.3",
         "1.18": "1.7.0",
         "1.17": "1.7.0",
         "1.16": "1.5.3",
         "1.16-Java16": "1.5.3",
-        "1.15": "1.0.0"
+        "1.15": "1.0.0",
+        "1.21.10": "1.9.4",
+        "1.21.11": "1.9.4",
+        "26.1.1": "1.9.4"
       }
     },
     {
       "name": "InvSwitcher",
-      "gamemode": false,
       "github": "BentoBoxWorld/InvSwitcher",
       "ci": "BentoBoxWorld/InvSwitcher",
       "description": "**InvSwitcher** is per-world switcher.\n\nWorld inventory switcher add-on for BentoBox. This add-on will work for any game modes.\n\nThe following can be switched per-world:\n\n* Inventory & armor\n* Advancements\n* Food level\n* Experience\n* Health\n* Enderchest contents\n\nUse the config to set what you want to be switched.\n\nCreated and maintained by [tastybento](https://github.com/tastybento).",
+      "gamemode": false,
       "versions": {
-        "1.21.6": "1.15.1", 
-        "1.21.5": "1.15.1", 
-        "1.21.4": "1.15.1", 
-        "1.21.3": "1.15.1", 
-        "1.21.1": "1.15.1", 
+        "1.21.6": "1.17.0",
+        "1.21.5": "1.17.0",
+        "1.21.4": "1.17.0",
+        "1.21.3": "1.17.0",
+        "1.21.1": "1.17.0",
         "1.20.6": "1.14.0",
         "1.19": "1.11.0",
         "1.18": "1.11.0",
         "1.17": "1.11.0",
         "1.16": "1.11.0",
         "1.16-Java16": "1.11.0",
-        "1.15": "1.8.2"
+        "1.15": "1.8.2",
+        "1.21.10": "1.17.0",
+        "1.21.11": "1.17.0",
+        "26.1.1": "1.17.0"
       }
     },
     {
       "name": "IslandFly",
-      "gamemode": false,
       "github": "BentoBoxWorld/IslandFly",
       "ci": "BentoBoxWorld/IslandFly",
       "description": "**IslandFly** lets your players **fly within their islands**!\n\nCreated and maintained by [tastybento](https://github.com/tastybento).",
+      "gamemode": false,
       "versions": {
-        "1.21.6": "1.14.2",
-        "1.21.5": "1.14.2",
-        "1.21.4": "1.14.2",
-        "1.21.3": "1.14.2",
-        "1.21.1": "1.13.0",
+        "1.21.6": "1.14.3",
+        "1.21.5": "1.14.3",
+        "1.21.4": "1.14.3",
+        "1.21.3": "1.14.3",
+        "1.21.1": "1.14.3",
         "1.20.6": "1.12.0",
         "1.19": "1.9.1",
         "1.18": "1.9.0",
         "1.17": "1.9.0",
         "1.16": "1.8.1",
         "1.16-Java16": "1.8.1",
-        "1.15": "1.7.0"
+        "1.15": "1.7.0",
+        "1.21.10": "1.14.3",
+        "1.21.11": "1.14.3",
+        "26.1.1": "1.14.3"
       }
     },
     {
       "name": "Level",
-      "gamemode": false,
       "github": "BentoBoxWorld/Level",
       "ci": "BentoBoxWorld/Level",
       "description": "**Level** creates a competitive atmosphere by making your players try to **have the highest island level**.\n\nCreated and maintained by [tastybento](https://github.com/tastybento).",
+      "gamemode": false,
       "versions": {
-        "1.21.6": "2.21.3",
-        "1.21.5": "2.21.3",
+        "1.21.6": "2.25.0",
+        "1.21.5": "2.25.0",
         "1.21.4": "2.21.3",
         "1.21.3": "2.21.3",
         "1.21.1": "2.21.3",
@@ -450,15 +507,18 @@
         "1.17": "2.9.0",
         "1.16": "2.6.5",
         "1.16-Java16": "2.9.0",
-        "1.15": "2.3.3"
+        "1.15": "2.3.3",
+        "1.21.11": "2.25.0",
+        "1.21.10": "2.25.0",
+        "26.1.1": "2.25.0"
       }
     },
     {
       "name": "Likes",
-      "gamemode": false,
       "github": "BentoBoxWorld/Likes",
       "ci": "BentoBoxWorld/Likes",
       "description": "**Likes** lets your players leave **likes or dislikes** on **islands they visit**.\n\nCreated and maintained by [BONNe](https://github.com/BONNe).",
+      "gamemode": false,
       "versions": {
         "1.21.6": "2.5.0",
         "1.21.5": "2.5.0",
@@ -471,36 +531,42 @@
         "1.17": "2.3.0",
         "1.16": "2.1.1",
         "1.16-Java16": "2.1.1",
-        "1.15": "1.7.1"
+        "1.15": "1.7.1",
+        "1.21.10": "2.5.0",
+        "1.21.11": "2.5.0",
+        "26.1.1": "2.5.0"
       }
     },
     {
       "name": "Limits",
-      "gamemode": false,
       "github": "BentoBoxWorld/Limits",
       "ci": "BentoBoxWorld/Limits",
       "description": "**Limits** let you limit how many blocks and entities your players can have on their islands.\n\nCreated and maintained by [tastybento](https://github.com/tastybento).",
+      "gamemode": false,
       "versions": {
-        "1.21.6": "1.27.0",
-        "1.21.5": "1.27.0",
-        "1.21.4": "1.27.0",
-        "1.21.3": "1.27.0",
-        "1.21.1": "1.27.0",
+        "1.21.6": "1.28.1",
+        "1.21.5": "1.28.1",
+        "1.21.4": "1.28.1",
+        "1.21.3": "1.28.1",
+        "1.21.1": "1.28.1",
         "1.20.6": "1.25.1",
         "1.19": "1.19.1",
         "1.18": "1.19.0",
         "1.17": "1.19.0",
         "1.16": "1.15.5",
         "1.16-Java16": "1.19.0",
-        "1.15": "1.12.1"
+        "1.15": "1.12.1",
+        "1.21.10": "1.28.1",
+        "1.21.11": "1.28.1",
+        "26.1.1": "1.28.1"
       }
     },
     {
       "name": "MagicCobblestoneGenerator",
-      "gamemode": false,
       "github": "BentoBoxWorld/MagicCobblestoneGenerator",
       "ci": "BentoBoxWorld/MagicCobblestoneGenerator",
       "description": "**MagicCobblestoneGenerator** provide players a simple and effective way to generate resources on their islands.\n\nSome specifications about this add-on:\n\n- Offline Generation - ability to disable addon processing on islands where none of members are online.\n- Disabled GameModes - specify Game Modes where MagicCobblestoneGenerator will not work.\n- Generator Tiers - ability to specify default generator tiers\n- GameMode Tiers - ability to specify generator tiers for specific game mode.\n\nCreated and maintained by [BONNe](https://github.com/BONNe).",
+      "gamemode": false,
       "versions": {
         "1.21.6": "2.7.0",
         "1.21.5": "2.7.0",
@@ -512,17 +578,22 @@
         "1.17": "2.3.0",
         "1.16": "2.3.0",
         "1.16-Java16": "2.3.0",
-        "1.15": "2.2.1"
+        "1.15": "2.2.1",
+        "1.21.10": "2.7.0",
+        "1.21.11": "2.7.0",
+        "26.1.1": "2.7.0"
       }
     },
     {
       "name": "Stranger Realms",
-      "gamemode": true,
       "github": "BentoBoxWorld/StrangerRealms",
       "ci": "BentoBoxWorld/StrangerRealms",
       "description": "**StrangerRealms** The familiar world is shadowed by a terrifying, inverted dimension — the Upside Down.",
+      "gamemode": true,
       "versions": {
-        "1.21.10": "1.0.0"
+        "1.21.10": "1.0.0",
+        "1.21.11": "1.0.0",
+        "26.1.1": "1.0.0"
       }
     },
     {
@@ -547,30 +618,33 @@
     },
     {
       "name": "Visit",
-      "gamemode": false,
       "github": "BentoBoxWorld/Visit",
       "ci": "BentoBoxWorld/Visit",
       "description": "**Visit** let your players visit other islands.\n\nThe main idea of the addon is to allow faster ways how to visit any island. The main difference from warps addon is that unlike warps, signs are not necessary, and users can travel to any island.\n\nCreated and maintained by [BONNe](https://github.com/BONNe).",
+      "gamemode": false,
       "versions": {
-        "1.21.6": "1.6.0",
-        "1.21.5": "1.6.0",
-        "1.21.4": "1.6.0",
-        "1.21.3": "1.6.0",
-        "1.20.6": "1.6.0",
+        "1.21.6": "1.7.0",
+        "1.21.5": "1.7.0",
+        "1.21.4": "1.7.0",
+        "1.21.3": "1.7.0",
+        "1.20.6": "1.7.0",
         "1.19": "1.6.0",
         "1.18": "1.4.0",
         "1.17": "1.4.0",
         "1.16": "1.3.0",
         "1.16-Java16": "1.3.0",
-        "1.15": "1.3.0"
+        "1.15": "1.3.0",
+        "1.21.10": "1.7.0",
+        "1.21.11": "1.7.0",
+        "26.1.1": "1.7.0"
       }
     },
     {
       "name": "VoidPortals",
-      "gamemode": false,
       "github": "BentoBoxWorld/VoidPortals",
       "ci": "BentoBoxWorld/VoidPortals",
       "description": "**VoidPortals** let your players teleport to other dimensions by jumping into the Void!\n\nCreated and maintained by [BONNe](https://github.com/BONNe).",
+      "gamemode": false,
       "versions": {
         "1.20.6": "1.5.0.1",
         "1.19": "1.5.0.0",
@@ -578,18 +652,21 @@
         "1.17": "1.5.0.0",
         "1.16": "1.5.0.0",
         "1.16-Java16": "1.5.0.0",
-        "1.15": "1.5.0.0"
+        "1.15": "1.5.0.0",
+        "1.21.10": "1.5.0.1",
+        "1.21.11": "1.5.0.1",
+        "26.1.1": "1.5.0.1"
       }
     },
     {
       "name": "Warps",
-      "gamemode": false,
       "github": "BentoBoxWorld/Warps",
       "ci": "BentoBoxWorld/Warps",
       "description": "**Warps** lets your players create Warps so that other players can visit their islands.\n\nCreated and maintained by [tastybento](https://github.com/tastybento).",
+      "gamemode": false,
       "versions": {
-        "1.21.6": "1.16.0",
-        "1.21.5": "1.16.0",
+        "1.21.6": "1.19.0",
+        "1.21.5": "1.19.0",
         "1.21.4": "1.16.0",
         "1.21.3": "1.16.0",
         "1.20.6": "1.15.0",
@@ -598,18 +675,24 @@
         "1.17": "1.12.0",
         "1.16": "1.10.2",
         "1.16-Java16": "1.10.2",
-        "1.15": "1.9.7"
+        "1.15": "1.9.7",
+        "1.21.10": "1.19.0",
+        "1.21.11": "1.19.0",
+        "26.1.1": "1.19.0"
       }
     },
     {
       "name": "BentoBox",
       "github": "BentoBoxWorld/BentoBox",
       "ci": "BentoBoxWorld/BentoBox",
-      "gamemode": false,
       "description": "BentoBox",
+      "gamemode": false,
       "versions": {
-        "1.21.6": "3.10.0",
-        "1.21.5": "3.10.0",
+        "26.1.1": "3.15.0",
+        "1.21.11": "3.15.0",
+        "1.21.10": "3.15.0",
+        "1.21.6": "3.15.0",
+        "1.21.5": "3.15.0",
         "1.21.4": "3.5.0",
         "1.21.3": "3.3.0",
         "1.21.1": "2.7.0",
@@ -634,11 +717,10 @@
         "Level",
         "Warps",
         "ControlPanel",
-        "DimensionalTrees",
         "Biomes",
         "Bank"
       ],
-      "color": "#ffdd57"
+      "color": "#5762ff"
     },
     {
       "name": "AOneBlock",
@@ -647,8 +729,9 @@
       "addons": [
         "AOneBlock",
         "Warps",
-        "Likes",
-        "Chat"
+        "Chat",
+        "InvSwitcher",
+        "Level"
       ],
       "color": "#48c774"
     },
@@ -664,9 +747,45 @@
         "ControlPanel",
         "DimensionalTrees",
         "Biomes",
-        "Bank"
+        "Bank",
+        "InvSwitcher"
       ],
       "color": "#ffdd57"
+    },
+    {
+      "name": "Boxed",
+      "description": "Survival in a Box!",
+      "subtext": "Complete Advancements to expand the box.\n\nIncludes these addons:",
+      "addons": [
+        "Boxed",
+        "InvSwitcher",
+        "Border"
+      ],
+      "color": "#48c774"
+    },
+    {
+      "name": "Poseidon",
+      "description": "Welcome to an underwater adventure!",
+      "subtext": "Where the ocean is both your playground and your challenge. Stranded in a shipwreck, you awaken with the ability to breathe underwater, but there’s a catch—you must keep moving, like a shark, to survive. Armed with a few essentials salvaged from a chest, your journey begins in the depths of the vast and mysterious sea.\n\nIncludes the following addons:",
+      "addons": [
+        "Poseidon",
+        "Challenges",
+        "Level",
+        "Warps",
+        "InvSwitcher"
+      ],
+      "color": "#ffdd57"
+    },
+    {
+      "name": "Stranger Realms",
+      "description": "The familiar world is shadowed by a terrifying, inverted dimension — the Upside Down.",
+      "subtext": "A chilling new survival experience where the familiar world is shadowed by a terrifying, inverted dimension. Stranger Realms is a custom BentoBox game mode that replaces the Nether with a dark, distressed copy of the Overworld — the Upside Down.",
+      "addons": [
+        "Stranger Realms",
+        "Warps",
+        "InvSwitcher"
+      ],
+      "color": "#cf1b21"
     },
     {
       "name": "CaveBlock",
@@ -683,41 +802,6 @@
         "Bank"
       ],
       "color": "#ffdd57"
-    },
-    {
-      "name": "Boxed",
-      "description": "Survival in a Box!",
-      "subtext": "Complete Advancements to expand the box.\n\nIncludes these addons:",
-      "addons": [
-        "Boxed",
-        "InvSwitcher",
-        "Border"
-      ],
-      "color": "#48c774"
-    },
-      {
-        "name": "Poseidon",
-        "description": "Welcome to an underwater adventure!",
-        "subtext": "Where the ocean is both your playground and your challenge. Stranded in a shipwreck, you awaken with the ability to breathe underwater, but there’s a catch—you must keep moving, like a shark, to survive. Armed with a few essentials salvaged from a chest, your journey begins in the depths of the vast and mysterious sea.\n\nIncludes the following addons:",
-        "addons": [
-          "Poseidon",
-          "Challenges",
-          "Level",
-          "Warps",
-          "InvSwitcher"
-        ],
-        "color": "#ffdd57"
-      },
-      {
-        "name": "Stranger Realms",
-        "description": "The familiar world is shadowed by a terrifying, inverted dimension — the Upside Down.",
-        "subtext": "A chilling new survival experience where the familiar world is shadowed by a terrifying, inverted dimension. Stranger Realms is a custom BentoBox game mode that replaces the Nether with a dark, distressed copy of the Overworld — the Upside Down.",
-        "addons": [
-          "Stranger Realms",
-          "Warps",
-          "InvSwitcher"
-        ],
-        "color": "#cf1b21"
-      }
+    }
   ]
 }


### PR DESCRIPTION
This PR syncs the live admin overrides back to `config.json`.
**Active overrides:** `presets`, `addons`
**Opened by:** Discord `272498407971487744`
### Recent audit entries
- `2026-04-26T23:53:25.814Z` · addons · 272498407971487744 — updated addon "BentoBox"
- `2026-04-26T23:52:41.732Z` · addons · 272498407971487744 — updated addon "BentoBox"
- `2026-04-26T23:39:04.702Z` · addons · 272498407971487744 — updated addon "CaveBlock"
- `2026-04-26T23:38:04.178Z` · addons · 272498407971487744 — updated addon "Boxed"
- `2026-04-26T23:37:44.238Z` · addons · 272498407971487744 — updated addon "BSkyBlock"
- `2026-04-26T23:37:06.070Z` · addons · 272498407971487744 — updated addon "Warps"
- `2026-04-26T23:36:22.834Z` · addons · 272498407971487744 — updated addon "VoidPortals"
- `2026-04-26T23:35:43.584Z` · addons · 272498407971487744 — updated addon "Visit"
- `2026-04-26T23:28:43.580Z` · addons · 272498407971487744 — updated addon "MagicCobblestoneGenerator"
- `2026-04-26T23:28:01.748Z` · addons · 272498407971487744 — updated addon "Limits"
- `2026-04-26T23:27:07.078Z` · addons · 272498407971487744 — updated addon "Likes"
- `2026-04-26T23:26:31.140Z` · addons · 272498407971487744 — updated addon "Level"
- `2026-04-26T23:25:37.900Z` · addons · 272498407971487744 — updated addon "IslandFly"
- `2026-04-26T23:24:47.296Z` · addons · 272498407971487744 — updated addon "InvSwitcher"
- `2026-04-26T23:23:53.798Z` · addons · 272498407971487744 — updated addon "Greenhouses"
- `2026-04-26T23:23:08.294Z` · addons · 272498407971487744 — updated addon "FarmersDance"
- `2026-04-26T23:22:21.161Z` · addons · 272498407971487744 — updated addon "ExtraMobs"
- `2026-04-26T23:21:42.438Z` · addons · 272498407971487744 — updated addon "DimensionalTrees"
- `2026-04-26T23:20:50.057Z` · addons · 272498407971487744 — updated addon "ControlPanel"
- `2026-04-26T23:19:57.087Z` · addons · 272498407971487744 — updated addon "CheckMeOut"